### PR TITLE
Fixed Match reserved keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zelenin/glicko2",
+    "name": "injektion/glicko2",
     "description": "A PHP implementation of Glicko2 rating system",
     "type": "library",
     "keywords": [
@@ -8,7 +8,7 @@
         "rating",
         "ranking"
     ],
-    "homepage": "https://github.com/zelenin/glicko2",
+    "homepage": "https://github.com/injektion/glicko2",
     "license": "MIT",
     "authors": [
         {
@@ -18,8 +18,8 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/zelenin/glicko2/issues",
-        "source": "https://github.com/zelenin/glicko2"
+        "issues": "https://github.com/injektion/glicko2/issues",
+        "source": "https://github.com/injektion/glicko2"
     },
     "require": {
         "php": ">=5.4.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.3.0"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -37,17 +37,17 @@ $glicko = new Glicko2();
 $player1 = new Player(1700, 250, 0.05);
 $player2 = new Player();
 
-$match = new Match($player1, $player2, 1, 0);
-$glicko->calculateMatch($match);
+$gameMatch = new Gamematch($player1, $player2, 1, 0);
+$glicko->calculateMatch($gameMatch);
 
-$match = new Match($player1, $player2, 3, 2);
-$glicko->calculateMatch($match);
+$gameMatch = new Gamematch($player1, $player2, 3, 2);
+$glicko->calculateMatch($gameMatch);
 
 // or
 
 $matchCollection = new MatchCollection();
-$matchCollection->addMatch(new Match($player1, $player2, 1, 0));
-$matchCollection->addMatch(new Match($player1, $player2, 3, 2));
+$matchCollection->addMatch(new Gamematch($player1, $player2, 1, 0));
+$matchCollection->addMatch(new Gamematch($player1, $player2, 3, 2));
 $glicko->calculateMatches($matchCollection);
 
 $newPlayer1R = $player1->getR();

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Create two players with current ratings:
 
 ```php
 use Zelenin\Glicko2\Glicko2;
-use Zelenin\Glicko2\Match;
+use Zelenin\Glicko2\Gamematch;
 use Zelenin\Glicko2\MatchCollection;
 use Zelenin\Glicko2\Player;
 

--- a/src/Gamematch.php
+++ b/src/Gamematch.php
@@ -2,7 +2,7 @@
 
 namespace Zelenin\Glicko2;
 
-final class Match
+final class Gamematch
 {
     /**
      * @var Player

--- a/src/Glicko2.php
+++ b/src/Glicko2.php
@@ -24,26 +24,26 @@ final class Glicko2
      */
     public function calculateMatches(MatchCollection $matchCollection)
     {
-        foreach ($matchCollection->getMatches() as $match) {
-            $this->calculateMatch($match);
+        foreach ($matchCollection->getMatches() as $gameMatch) {
+            $this->calculateMatch($gameMatch);
         }
     }
 
     /**
-     * @param Match $match
+     * @param Gamematch $gameMatch
      */
-    public function calculateMatch(Match $match)
+    public function calculateMatch(Gamematch $gameMatch)
     {
-        $player1 = clone $match->getPlayer1();
-        $player2 = clone $match->getPlayer2();
+        $player1 = clone $gameMatch->getPlayer1();
+        $player2 = clone $gameMatch->getPlayer2();
 
-        $score = $match->getScore();
+        $score = $gameMatch->getScore();
 
         $calculationResult1 = $this->calculatePlayer($player1, $player2, $score);
         $calculationResult2 = $this->calculatePlayer($player2, $player1, (1 - $score));
 
-        $match->getPlayer1()->loadFromCalculationResult($calculationResult1);
-        $match->getPlayer2()->loadFromCalculationResult($calculationResult2);
+        $gameMatch->getPlayer1()->loadFromCalculationResult($calculationResult1);
+        $gameMatch->getPlayer2()->loadFromCalculationResult($calculationResult2);
     }
 
     /**

--- a/src/MatchCollection.php
+++ b/src/MatchCollection.php
@@ -18,11 +18,11 @@ final class MatchCollection
     }
 
     /**
-     * @param Match $match
+     * @param Gamematch $gameMatch
      */
-    public function addMatch(Match $match)
+    public function addMatch(Gamematch $gameMatch)
     {
-        $this->matches->append($match);
+        $this->matches->append($gameMatch);
     }
 
     /**

--- a/tests/Glicko2Test.php
+++ b/tests/Glicko2Test.php
@@ -2,24 +2,25 @@
 
 namespace Zelenin\Glicko2\Test;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Zelenin\Glicko2\Glicko2;
-use Zelenin\Glicko2\Match;
+use Zelenin\Glicko2\Gamematch;
 use Zelenin\Glicko2\MatchCollection;
 use Zelenin\Glicko2\Player;
 
-final class Glicko2Test extends PHPUnit_Framework_TestCase
+final class Glicko2Test extends TestCase
 {
     /**
      * @var Glicko2
      */
     private $glicko;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->glicko = new Glicko2();
         parent::setUp();
     }
+
 
     public function testDefaultPlayer()
     {
@@ -48,8 +49,8 @@ final class Glicko2Test extends PHPUnit_Framework_TestCase
         $player1 = new Player(1500, 200, 0.06);
         $player2 = new Player(1400, 30, 0.06);
 
-        $match = new Match($player1, $player2, 1, 0);
-        $this->glicko->calculateMatch($match);
+        $gameMatch = new Gamematch($player1, $player2, 1, 0);
+        $this->glicko->calculateMatch($gameMatch);
 
         $this->assertEquals(1563.564, $this->round($player1->getR()));
         $this->assertEquals(175.403, $this->round($player1->getRd()));
@@ -68,14 +69,14 @@ final class Glicko2Test extends PHPUnit_Framework_TestCase
         $player3 = clone $player1;
         $player4 = clone $player2;
 
-        $match = new Match($player1, $player2, 1, 0);
-        $this->glicko->calculateMatch($match);
-        $match = new Match($player1, $player2, 1, 0);
-        $this->glicko->calculateMatch($match);
+        $gameMatch = new Gamematch($player1, $player2, 1, 0);
+        $this->glicko->calculateMatch($gameMatch);
+        $gameMatch = new Gamematch($player1, $player2, 1, 0);
+        $this->glicko->calculateMatch($gameMatch);
 
         $matchCollection = new MatchCollection();
-        $matchCollection->addMatch(new Match($player3, $player4, 1, 0));
-        $matchCollection->addMatch(new Match($player3, $player4, 1, 0));
+        $matchCollection->addMatch(new Gamematch($player3, $player4, 1, 0));
+        $matchCollection->addMatch(new Gamematch($player3, $player4, 1, 0));
         $this->glicko->calculateMatches($matchCollection);
 
         $this->assertEquals($this->round($player1->getR()), $this->round($player3->getR()));


### PR DESCRIPTION
Match has been a reserved keyword since PHP 8.0
Caused Zelenin\Glicko2\Match to get fussy and die.
This PR changes \Match to \Gamematch and updates all $match variables to $gameMatch.

Updated the tests to work with recent psr versions and everything's passing fine... 

Not sure if you're up for an update after 9 years (!?!) so while i keep your namespace, i've updated composer.json to my fork just so I can call it thru composer and packagist.

Use this PR as you see fit, and thank you for your work 🙏